### PR TITLE
authenticity token skipped before action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+.env*

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'acts-as-taggable-on', '~> 6.0'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
+
+gem 'dotenv-rails', groups: [:development, :test]
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BaseController < ActionController::Base
-
+  skip_before_action :verify_authenticity_token
   rescue_from StandardError,                with: :internal_server_error
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 

--- a/app/controllers/api/v1/spots_controller.rb
+++ b/app/controllers/api/v1/spots_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::SpotsController < Api::V1::BaseController
       render :show
       # The render allows WeChat frontend to see what's going on when adding a new element.
     else
-      render_error
+      # render_error
     end
   end
 

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -1,0 +1,32 @@
+class LoginController < ApplicationController
+
+skip_before_action :verify_authenticity_token
+
+URL = "https://api.weixin.qq.com/sns/jscode2session".freeze
+
+def wechat_params
+  {
+    appid: ENV['APP_ID'],
+    secret: ENV['SECRET'],
+    js_code: params[:code],
+    grant_type: "authorization_code"
+  }
+end
+
+def wechat_user
+  @wechat_response ||= RestClient.post(URL, wechat_params)
+  @wechat_user ||= JSON.parse(@wechat_response.body)
+end
+
+def login
+  # Would need to extract user avatar's URL when he logs in.
+  # Need to store the avatar in User instance.
+  open_id = wechat_user.fetch("openid")
+  puts "open_id", open_id
+  @user = User.find_or_create_by(open_id: open_id)
+  puts "user", @user.inspect
+  render json: {
+    userId: @user.id
+  }
+end
+end


### PR DESCRIPTION
In Base Controller, the following line has been added:
skip_before_action :verify_authenticity_token

To avoid authenticity token issues in WeChat.