### PR TITLE
Geocoder

### DIFF
--- a/app/views/api/v1/spots/index.json.jbuilder
+++ b/app/views/api/v1/spots/index.json.jbuilder
@@ -2,10 +2,9 @@ json.spots do
   json.array! @spots do |spot|
     json.extract! spot, :id, :name, :description, :address, :longitude, :latitude, :user_id, :tag_list, :cached_votes_total
     json.images do
-      json.array! @images do |image|
+      json.array! @spot.images do |image|
         json.extract! image, :id, :url
       end
     end
   end
-
 end

--- a/app/views/api/v1/spots/show.json.jbuilder
+++ b/app/views/api/v1/spots/show.json.jbuilder
@@ -7,7 +7,7 @@ json.spot do
   end
 
   json.images do
-    json.array! @images do |image|
+    json.array! @spot.images do |image|
       json.extract! image, :id, :url
     end
   end


### PR DESCRIPTION
Show page API provides spot's corresponding images.
Index page API should do the same, but need to delete seed and create new spots with images otherwise an error occurs and "images" attribute of spot will be nil.